### PR TITLE
Add Spring Boot Starter for OPA ABAC to Java integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ A curated list of [awesome](https://github.com/sindresorhus/awesome) Open Policy
 - [Spring Security Reactive](https://github.com/massenz/jwt-opa) - OPA with Spring Security Reactive
 - [Gradle](https://github.com/Bisnode/opa-gradle-plugin) - OPA plugin for Gradle
 - [Thunx](https://github.com/xenit-eu/thunx) - Thunx is a pluggable ABAC system using OPA, Spring Cloud Gateway and Spring Data REST
+- [Spring Boot Starter for OPA ABAC](https://github.com/Void3110/spring-boot-starter-opa-abac) - Spring-native ABAC authorization backed by OPA: `@OpaPreAuthorize` method security, hierarchical resource authorization, and partial-evaluation → JPA `Specification` data filtering
 
 ### Python
 


### PR DESCRIPTION
Adds [spring-boot-starter-opa-abac](https://github.com/Void3110/spring-boot-starter-opa-abac) to the **Java** integrations section.

**How it uses OPA:** it's a Spring-native library for attribute-based access control (ABAC) backed by OPA. It integrates OPA at three layers:
- **`@OpaPreAuthorize`** method security — the authorization decision comes from OPA (an `AuthorizationManager` calls the OPA REST API with a rich attribute context).
- **Hierarchical resource authorization** — a grant on a parent resource governs nested children N levels deep, evaluated in Rego.
- **Partial-evaluation data filtering** — uses OPA's Compile API (partial evaluation) to turn a policy into a JPA `Specification`, so list endpoints return only the rows a subject may see, filtered in SQL.

It's published on Maven Central (`dev.dmitriikonovalov:opa-abac-*`), Apache-2.0, with a runnable example (APISIX → OPA → service → Postgres), integration tests, and `opa test` policy coverage. Placed alongside the existing Spring entries in the Java section.