### PR TITLE
Add GOPAL to Policy Packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ A curated list of [awesome](https://github.com/sindresorhus/awesome) Open Policy
 - [Kubescape Rego library](https://github.com/kubescape/regolibrary) - Comprehensive set of Kubernetes policies from Kubescape
 - [Kubernetes Security Policies](https://github.com/raspbernetes/k8s-security-policies) - Raspernetes library for fortifying cluster configurations
 - [agt-policies-nigeria](https://github.com/kingztech2019/agt-policies-nigeria) - Policy-as-Code for African AI agent compliance: NDPA 2023, CBN transaction limits, BVN/NIN data protection, NFIU AML/CFT, and POPIA. Includes 88 OPA tests, CI pipeline, and full compliance mapping.
+- [GOPAL](https://github.com/Principled-Evolution/gopal) - 66 Rego policies encoding AI-governance regulations as executable checks: EU AI Act, NIST AI RMF, FERPA/COPPA, fair lending. Versioned under `v1/` with semver guarantees, allow/deny test per policy, `opa check` + Regal in CI.
 
 
 ## Language and Platform Integrations


### PR DESCRIPTION
Adding GOPAL, a Rego policy library for AI governance compliance (EU AI Act, NIST AI RMF, education, banking). 66 policies, each with its own test file, checked with opa check and Regal in CI.

Placed it next to the other compliance-as-code entries in Policy Packages. Happy to move it or trim the description if it doesn't fit.