### PR TITLE
Update the GOPAL entry: current frameworks, coverage matrices, CI gates

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ A curated list of [awesome](https://github.com/sindresorhus/awesome) Open Policy
 - [Kubescape Rego library](https://github.com/kubescape/regolibrary) - Comprehensive set of Kubernetes policies from Kubescape
 - [Kubernetes Security Policies](https://github.com/raspbernetes/k8s-security-policies) - Raspernetes library for fortifying cluster configurations
 - [agt-policies-nigeria](https://github.com/kingztech2019/agt-policies-nigeria) - Policy-as-Code for African AI agent compliance: NDPA 2023, CBN transaction limits, BVN/NIN data protection, NFIU AML/CFT, and POPIA. Includes 88 OPA tests, CI pipeline, and full compliance mapping.
-- [GOPAL](https://github.com/Principled-Evolution/gopal) - 85 Rego policies encoding AI-governance regulations as executable checks: EU AI Act, NIST AI RMF, ICAO/FAA/EASA aviation, FERPA/COPPA, fair lending, healthcare, automotive. Versioned under `v1/` with semver guarantees, allow/deny tests per policy, `opa check` + Regal in CI.
+- [GOPAL](https://github.com/Principled-Evolution/gopal) - Rego policies encoding AI-governance regulations as executable allow/deny checks: EU AI Act, UK pro-innovation principles and UK GDPR Arts 22A-22D, NIST AI RMF, ICAO/FAA/EASA aviation, PRA SS1/23, FCA Consumer Duty, FERPA/COPPA, fair lending. Every obligation in its published per-article coverage matrices is implemented; each framework is versioned under `v1/` with semver guarantees, and `opa check`, Regal and `opa test` run in CI.
 
 
 ## Language and Platform Integrations

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ A curated list of [awesome](https://github.com/sindresorhus/awesome) Open Policy
 - [Kubescape Rego library](https://github.com/kubescape/regolibrary) - Comprehensive set of Kubernetes policies from Kubescape
 - [Kubernetes Security Policies](https://github.com/raspbernetes/k8s-security-policies) - Raspernetes library for fortifying cluster configurations
 - [agt-policies-nigeria](https://github.com/kingztech2019/agt-policies-nigeria) - Policy-as-Code for African AI agent compliance: NDPA 2023, CBN transaction limits, BVN/NIN data protection, NFIU AML/CFT, and POPIA. Includes 88 OPA tests, CI pipeline, and full compliance mapping.
-- [GOPAL](https://github.com/Principled-Evolution/gopal) - 66 Rego policies encoding AI-governance regulations as executable checks: EU AI Act, NIST AI RMF, FERPA/COPPA, fair lending. Versioned under `v1/` with semver guarantees, allow/deny test per policy, `opa check` + Regal in CI.
+- [GOPAL](https://github.com/Principled-Evolution/gopal) - 85 Rego policies encoding AI-governance regulations as executable checks: EU AI Act, NIST AI RMF, ICAO/FAA/EASA aviation, FERPA/COPPA, fair lending, healthcare, automotive. Versioned under `v1/` with semver guarantees, allow/deny tests per policy, `opa check` + Regal in CI.
 
 
 ## Language and Platform Integrations


### PR DESCRIPTION
Disclosure: I maintain GOPAL.

The entry was written when GOPAL had 66 policies and no aviation coverage, and it leads with a raw policy count. Since then the aviation frameworks (ICAO Doc 10019, FAA Part 107 and Remote ID, EASA 2019/947 and SORA, RTCA DO-365, ISO 21384), a UK framework (the pro-innovation principles plus UK GDPR Articles 22A-22D as substituted by the Data (Use and Access) Act 2025), UK financial services (PRA SS1/23, FCA Consumer Duty) and a legal-practice vertical have all landed.

I have dropped the count rather than updating it again. It changed twice while this PR was open, and it is not the useful signal for someone browsing this list: they want to know whether their framework is covered. What the entry says instead is verifiable:

- **Every obligation in the published per-article coverage matrices is implemented.** Until this week that was not true; 22 of the 29 EU AI Act policies were `allow := false` placeholders. They are now real checks with tests, and the [matrix](https://github.com/Principled-Evolution/gopal/blob/main/docs/coverage/eu-ai-act.md) has no scaffold rows.
- Each framework is pinned under `v1/` with semver guarantees, so an amended regulation ships as `v2/` alongside rather than breaking a pin.
- `opa check`, Regal and `opa test` all run in CI. 604 tests at [v1.2.0](https://github.com/Principled-Evolution/gopal/releases/tag/v1.2.0).

One line changed, same style as the surrounding entries. DCO signed off.